### PR TITLE
Break up packages

### DIFF
--- a/fc/fc.go
+++ b/fc/fc.go
@@ -98,6 +98,18 @@ func (f *FC) reconnect() error {
 	}
 }
 
+func (f *FC) Close() error {
+	if f.msp != nil {
+		err := f.msp.Close()
+		f.msp = nil
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (f *FC) updateInfo() {
 	// Send commands to print FC info
 	f.msp.WriteCmd(_msp.MspAPIVersion)

--- a/main.go
+++ b/main.go
@@ -31,6 +31,9 @@ const (
 	kmArrowUp    = 255
 )
 
+type MyPIDReceiver struct {
+}
+
 type keyboardMonitor struct {
 	t     *term.Term
 	isRaw bool
@@ -167,7 +170,7 @@ func main() {
 
 	go func() {
 		defer km.Close()
-		fc.StartUpdating()
+		fc.StartUpdating(MyPIDReceiver{})
 	}()
 	input := make(chan byte)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/fiam/msp-tool/fc"
+	"github.com/fiam/msp-tool/rx"
 	"github.com/pkg/term"
 )
 
@@ -108,25 +110,25 @@ q	Quit
 	fmt.Fprint(w, help)
 }
 
-func handleRXSimulation(fc *FC, key byte) bool {
-	var rxKey RXKey
+func handleRXSimulation(fc *fc.FC, key byte) bool {
+	var rxKey rx.RXKey
 	switch key {
 	case 'w':
-		rxKey = RXKeyW
+		rxKey = rx.RXKeyW
 	case 'a':
-		rxKey = RXKeyA
+		rxKey = rx.RXKeyA
 	case 's':
-		rxKey = RXKeyS
+		rxKey = rx.RXKeyS
 	case 'd':
-		rxKey = RXKeyD
+		rxKey = rx.RXKeyD
 	case kmArrowUp:
-		rxKey = RXKeyUp
+		rxKey = rx.RXKeyUp
 	case kmArrowLeft:
-		rxKey = RXKeyLeft
+		rxKey = rx.RXKeyLeft
 	case kmArrowDown:
-		rxKey = RXKeyDown
+		rxKey = rx.RXKeyDown
 	case kmArrowRight:
-		rxKey = RXKeyRight
+		rxKey = rx.RXKeyRight
 	default:
 		return false
 	}
@@ -149,13 +151,13 @@ func main() {
 
 	defer km.Close()
 
-	opts := FCOptions{
+	opts := fc.FCOptions{
 		PortName:         *portName,
 		BaudRate:         *baudRate,
 		Stdout:           km,
 		EnableDebugTrace: !*doNotEnableDebugTrace,
 	}
-	fc, err := NewFC(opts)
+	fc, err := fc.NewFC(opts)
 	if err != nil {
 		km.Close()
 		log.Fatal(err)

--- a/msp/README.md
+++ b/msp/README.md
@@ -1,0 +1,7 @@
+# MSP protocol
+
+Resources from:
+
+* http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol
+* http://armazila.com/MultiwiiSerialProtocol(draft)v02.pdf
+* https://stackoverflow.com/questions/42877001/how-do-i-read-gyro-information-from-cleanflight-using-msp

--- a/msp/msp.go
+++ b/msp/msp.go
@@ -1,4 +1,4 @@
-package main
+package msp
 
 import (
 	"bytes"
@@ -11,36 +11,36 @@ import (
 )
 
 const (
-	mspAPIVersion = 1
-	mspFCVariant  = 2
-	mspFCVersion  = 3
-	mspBoardInfo  = 4
-	mspBuildInfo  = 5
+	MspAPIVersion = 1
+	MspFCVariant  = 2
+	MspFCVersion  = 3
+	MspBoardInfo  = 4
+	MspBuildInfo  = 5
 
-	mspFeature    = 36
-	mspSetFeature = 37
+	MspFeature    = 36
+	MspSetFeature = 37
 
-	mspCFSerialConfig    = 54
-	mspSetCFSerialConfig = 55
+	MspCFSerialConfig    = 54
+	MspSetCFSerialConfig = 55
 
-	mspRXMap = 64
+	MspRXMap = 64
 
-	mspReboot = 68
+	MspReboot = 68
 
-	mspSetRawRC = 200
+	MspSetRawRC = 200
 
-	mspEepromWrite = 250
+	MspEepromWrite = 250
 
-	mspDebugMsg = 253
+	MspDebugMsg = 253
 )
 
 const (
-	mspFCFeatureDebugTrace = 1 << 31
+	MspFCFeatureDebugTrace = 1 << 31
 )
 
 const (
-	serialFunctionMSP        = 1 << 0
-	serialFunctionDebugTrace = 1 << 15
+	SerialFunctionMSP        = 1 << 0
+	SerialFunctionDebugTrace = 1 << 15
 )
 
 func mspV1Encode(cmd byte, data []byte) []byte {

--- a/msp/msp.go
+++ b/msp/msp.go
@@ -27,7 +27,11 @@ const (
 
 	MspReboot = 68
 
+	MspPID = 112
+
 	MspSetRawRC = 200
+
+	MspSetPID = 202
 
 	MspEepromWrite = 250
 

--- a/msp/msp_types.go
+++ b/msp/msp_types.go
@@ -1,4 +1,4 @@
-package main
+package msp
 
 type MSPSerialConfig struct {
 	Identifier              uint8

--- a/rx/rx.go
+++ b/rx/rx.go
@@ -1,4 +1,4 @@
-package main
+package rx
 
 import (
 	"sync"
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	rxLow  = 1000
-	rxMid  = 1500
-	rxHigh = 2000
+	RxLow  = 1000
+	RxMid  = 1500
+	RxHigh = 2000
 )
 
 const (
@@ -34,7 +34,7 @@ type RX interface {
 	Keypress(key RXKey)
 }
 
-type rxSticks struct {
+type RxSticks struct {
 	Roll      uint16
 	Pitch     uint16
 	Yaw       uint16
@@ -43,7 +43,7 @@ type rxSticks struct {
 	lastPress [8]time.Time
 }
 
-func (r *rxSticks) ToMSP(channelMap []uint8) rxPayload {
+func (r *RxSticks) ToMSP(channelMap []uint8) rxPayload {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	channels := make([]uint16, 4)
@@ -56,39 +56,39 @@ func (r *rxSticks) ToMSP(channelMap []uint8) rxPayload {
 	}
 }
 
-func (r *rxSticks) Keypress(key RXKey) {
+func (r *RxSticks) Keypress(key RXKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	switch key {
 	case RXKeyW:
-		r.Throttle = rxHigh
+		r.Throttle = RxHigh
 		r.lastPress[RXKeyS] = time.Time{}
 	case RXKeyA:
-		r.Yaw = rxLow
+		r.Yaw = RxLow
 		r.lastPress[RXKeyD] = time.Time{}
 	case RXKeyS:
-		r.Throttle = rxLow
+		r.Throttle = RxLow
 		r.lastPress[RXKeyW] = time.Time{}
 	case RXKeyD:
-		r.Yaw = rxHigh
+		r.Yaw = RxHigh
 		r.lastPress[RXKeyA] = time.Time{}
 	case RXKeyUp:
-		r.Pitch = rxHigh
+		r.Pitch = RxHigh
 		r.lastPress[RXKeyDown] = time.Time{}
 	case RXKeyLeft:
-		r.Roll = rxLow
+		r.Roll = RxLow
 		r.lastPress[RXKeyRight] = time.Time{}
 	case RXKeyDown:
-		r.Pitch = rxLow
+		r.Pitch = RxLow
 		r.lastPress[RXKeyUp] = time.Time{}
 	case RXKeyRight:
-		r.Roll = rxHigh
+		r.Roll = RxHigh
 		r.lastPress[RXKeyRight] = time.Time{}
 	}
 	r.lastPress[key] = time.Now()
 }
 
-func (r *rxSticks) Update() {
+func (r *RxSticks) Update() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	now := time.Now()
@@ -100,13 +100,13 @@ func (r *rxSticks) Update() {
 			r.lastPress[ii] = time.Time{}
 			switch RXKey(ii) {
 			case RXKeyW, RXKeyS:
-				r.Throttle = rxMid
+				r.Throttle = RxMid
 			case RXKeyA, RXKeyD:
-				r.Yaw = rxMid
+				r.Yaw = RxMid
 			case RXKeyUp, RXKeyDown:
-				r.Pitch = rxMid
+				r.Pitch = RxMid
 			case RXKeyLeft, RXKeyRight:
-				r.Roll = rxMid
+				r.Roll = RxMid
 			}
 		}
 	}


### PR DESCRIPTION
I'm working on an application that doesn't need the CLI parts but needs the basic libraries behind `msp` and `fc`.  This PR breaks apart the library into multiple packages that can be easily imported into other projects.

This PR also has a framework for allowing callbacks via an empty interface pattern.

Some of this needs to be cleaned up, but I wanted to open this PR to start the conversation on this.